### PR TITLE
Added frankfurt to regions and updated aws sdk version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,12 +7,12 @@
     <groupId>org.zalando.org.springframework.build</groupId>
     <artifactId>aws-maven</artifactId>
     <packaging>jar</packaging>
-    <version>5.0.0.RELEASE-zal-1</version>
+    <version>5.0.0.RELEASE-zal-2</version>
     <name>Amazon Web Services S3 Maven Wagon Support</name>
     <description>Standard Maven wagon support for s3:// urls</description>
 
     <properties>
-        <amazonaws.version>1.10.34</amazonaws.version>
+        <amazonaws.version>1.11.39</amazonaws.version>
         <junit.version>4.11</junit.version>
         <logback.version>1.1.1</logback.version>
         <mockito.version>1.9.5</mockito.version>

--- a/src/main/java/org/springframework/build/aws/maven/Region.java
+++ b/src/main/java/org/springframework/build/aws/maven/Region.java
@@ -21,6 +21,7 @@ enum Region {
     US_WEST_OREGON("us-west-2", "s3-us-west-2.amazonaws.com"), //
     US_WEST_NORTHERN_CALIFORNIA("us-west-1", "s3-us-west-1.amazonaws.com"), //
     EU("EU", "s3-eu-west-1.amazonaws.com"), //
+    EU_FRANKFURT("eu-central-1", "s3-eu-central-1.amazonaws.com"), //
     EU_IRELAND("eu-west-1", "s3-eu-west-1.amazonaws.com"), //
     GOV_CLOUD("us-gov-west-1", "us-gov-west-1.amazonaws.com"), //
     ASIA_PACIFIC_SINGAPORE("ap-southeast-1", "s3-ap-southeast-1.amazonaws.com"), //


### PR DESCRIPTION
_Problem_:
With the current version of this S3 wagon it isn't possible to use the region eu-central-1, because this region was missing in the list.

Therefore I added the region and updated the aws sdk version to support newest AWS4-HMAC-SHA256 encryption method.

@dryewo Could you please review, merge and deploy this to the public maven repo again?
